### PR TITLE
Feature/xml compatibility implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+### [1.0.5](https://github.com/magestat/magento2-log-webapi/releases/tag/1.0.5) - 05/20/2020
+#### Improved
+- Compatibility with XML formatted requests.
+
+#### Fixed
+- Issue that caused portion of request/response data missing in log.
+
 ### [1.0.4](https://github.com/magestat/magento2-log-webapi/releases/tag/1.0.4) - 02/17/2020
 #### Added
 - ACL for this module

--- a/Model/Logger.php
+++ b/Model/Logger.php
@@ -131,7 +131,7 @@ class Logger implements LoggerInterface
         $needleKey = \explode(self::SEPARATOR, $this->helper->filters());
 
         foreach ($array as $key => $value) {
-            if (\in_array($key, $needleKey)) {
+            if (\in_array((string) $key, $needleKey)) {
                 unset($array[$key]);
             }
 

--- a/Model/Logger.php
+++ b/Model/Logger.php
@@ -5,7 +5,6 @@ namespace Magestat\LogWebapi\Model;
 use Magento\Framework\Exception\ValidatorException;
 use Magento\Framework\Serialize\SerializerInterface;
 use Magento\Framework\HTTP\PhpEnvironment\Request as HttpRequest;
-use Magento\Framework\Webapi\Rest\Request\Deserializer\Xml;
 use Magestat\LogWebapi\Api\LoggerInterface;
 use Magestat\LogWebapi\Api\Handler\LogFileInterface;
 use Magestat\LogWebapi\Helper\Data as Helper;

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "This extension creates a log file and saves all transactions that are requested through your store's Rest API.",
     "type": "magento2-module",
     "license": "OSL-3.0",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "support": {
         "issues": "https://github.com/magestat/magento2-log-webapi/issues/"
     },


### PR DESCRIPTION
Extension update to version `1.0.5`.

### Description
This PR introduces improvements to the `Magestat\LogWebapi\Model\Logger` class. Few methods were updated to address issues with requests that have `Content-Type: application/xml` header set.
Current version will be able to handle two `Content-Type` values: `application/json` and `application/xml`. Compatibility with older version is preserved.

Further improvement: use xml configuration to inject available handlers for different `Content-Type` values.

Second portion of work addresses issue, which I have discovered during different data format verification. I discovered, that if a request body has a data structure that was converted to array with a 0 as an index, that item would be removed from logged data. Example below.
Json string representation.
```
{
	"productSkuList": [
		"0000212121","0000212122","0000212141","0000212114"
	]
}
```
PHP array representation (abstract code):
```
object(stdClass)#1 (1) {
  ["productSkuList"]=>
  array(4) {
    [0]=> string(10) "0000212121"
    [1]=> string(10) "0000212122"
    [2]=> string(10) "0000212141"
    [3]=> string(10) "0000212114"
  }
```
After filtering data with `Magestat\LogWebapi\Model\Logger::filterContent` method, element with index 0 would be removed. That's why key to string casting on line 134 was added.

### Fixed Issues
This PR fixes these issues:
1. magestat/magento2-log-webapi#6: Extension throws an exception if input data formatted as XML.
